### PR TITLE
Align OpenAI requests with GPT-5 token limits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,10 @@
 name: deploy to lambda
 on:
-  # Trigger the workflow on push or pull request,
-  # but only for the main branch
+  # Trigger the workflow on push for main and develop branches
   push:
     branches:
       - main
+      - develop
 jobs:
   deploy_source:
     name: deploy lambda from source

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a conversational assistant for Telegram running on AWS Lambda and DynamoDB and using OpenAI API to generate answers.
 
+New capabilities:
+- Vision understanding when users attach Telegram photos.
+- Image generation through Gemini when the model triggers the dedicated tool.
+
 To connect the Lambda function to you Telegram bot run:
 
 ```bash
@@ -24,9 +28,17 @@ Environmental Variables:
 | DYNAMODB_TABLE_NAME | DynamoDB table name                                         |
 | RESET_COMMAND       | the Telegram bot command to reset the history               |
 | BOT_NAME            | the name of the bot as it is in Telegram                    |
-| MAX_TOKENS          | number of tokens in model response                          |
-| PRESENCE_PENALTY    | presence penalty model parameter                            |
-| FREQUENCY_PENALTY   | frequency penalty model parameter                           |
-| TOP_P               | top_p model parameter                                       |
+| MAX_TOKENS          | maximum completion tokens (sent as `max_completion_tokens`) |
+| PRESENCE_PENALTY    | deprecated for GPT-5 (ignored)                              |
+| FREQUENCY_PENALTY   | deprecated for GPT-5 (ignored)                              |
+| TOP_P               | deprecated for GPT-5 (ignored)                              |
 | TEMPERATURE         | temperature model parameter                                 |
+| GEMINI_API_KEY      | API key for Gemini image generation                         |
+| GEMINI_IMAGE_MODEL  | Gemini model name for image creation (default: gemini-2.5-flash-image) |
+| IMAGE_MIME_TYPE     | MIME type for generated images (e.g., image/png)            |
+
+Deployment notes:
+- Update the Lambda layer/package with the refreshed `requirements.txt` (OpenAI and google-generativeai).
+- Ensure the Telegram webhook is still configured with the API Gateway URL after deployment.
+- Grant the function access to DynamoDB and allow outbound HTTPS so it can reach Telegram, OpenAI, and Gemini endpoints.
 

--- a/dinamodb_client.py
+++ b/dinamodb_client.py
@@ -1,47 +1,81 @@
 import os
 import boto3
 import json
+from typing import List, Dict, Any
 
 from botocore.exceptions import ClientError
 
-DYNAMODB_TABLE_NAME = os.environ.get('DYNAMODB_TABLE_NAME') 
+DYNAMODB_TABLE_NAME = os.environ.get('DYNAMODB_TABLE_NAME')
 
 dynamodb = boto3.resource('dynamodb')
+
 
 class dynamoDBClient:
     def __init__(self) -> None:
         pass
-    
-    def save_messages(self, table_id, messages):
-        """ Save messages to a DynamoDB table"""
+
+    def _encode_messages(self, messages: List[Dict[str, Any]]):
+        return "\n\n".join([json.dumps(message) for message in messages])
+
+    def save_messages(self, table_id, messages: List[Dict[str, Any]]):
+        """Save messages to a DynamoDB table"""
         data = {
             'chat_id': table_id,
-            'messages': "\n\n".join([json.dumps(message) for message in messages])
+            'messages': self._encode_messages(messages)
         }
         table = dynamodb.Table(DYNAMODB_TABLE_NAME)
         response = table.put_item(Item=data)
         return response
 
-    def load_messages(self, table_id):
-        """ Load messages from a DynamoDB table"""
+    def _decode_message(self, raw_message: str, index: int) -> Dict[str, Any]:
+        try:
+            message_obj = json.loads(raw_message)
+        except json.JSONDecodeError:
+            message_obj = {
+                "role": "user",
+                "username": "legacy_user",
+                "text": raw_message,
+                "id": f"legacy-{index}",
+                "reply_to_id": None,
+                "images": []
+            }
+        if isinstance(message_obj, str):
+            message_obj = {
+                "role": "user",
+                "username": "legacy_user",
+                "text": message_obj,
+                "id": f"legacy-{index}",
+                "reply_to_id": None,
+                "images": []
+            }
+        message_obj.setdefault("id", f"legacy-{index}")
+        message_obj.setdefault("reply_to_id", None)
+        message_obj.setdefault("username", "legacy_user")
+        message_obj.setdefault("text", "")
+        message_obj.setdefault("images", [])
+        message_obj.setdefault("role", "user")
+        return message_obj
+
+    def load_messages(self, table_id) -> List[Dict[str, Any]]:
+        """Load messages from a DynamoDB table"""
         table = dynamodb.Table(DYNAMODB_TABLE_NAME)
 
         try:
             response = table.get_item(Key={'chat_id': table_id})
         except ClientError as e:
             print(e.response['Error']['Message'])
-            messages = []
+            messages: List[Dict[str, Any]] = []
         else:
             if 'Item' in response:
-                messages = response['Item']["messages"].split("\n\n")
+                raw_messages = response['Item']["messages"].split("\n\n")
+                messages = [self._decode_message(message, index) for index, message in enumerate(raw_messages)]
             else:
-                messages =  []
-                    
-        messages = [json.loads(message) for message in messages]
+                messages = []
+
         return messages
-    
+
     def reset_chat(self, table_id):
-        """ Reset a chat in a DynamoDB table"""
+        """Reset a chat in a DynamoDB table"""
         table = dynamodb.Table(DYNAMODB_TABLE_NAME)
         response = table.delete_item(Key={'chat_id': table_id})
         return response

--- a/openai_client.py
+++ b/openai_client.py
@@ -1,7 +1,11 @@
+import base64
 import os
-import openai
 import json
-import random
+import uuid
+from typing import Any, Dict, List, Optional
+
+from google import generativeai as genai
+from openai import OpenAI
 
 from dinamodb_client import dynamoDBClient
 
@@ -11,37 +15,220 @@ SYSTEM_PROMPT = os.environ.get('SYSTEM_PROMPT')
 STYLE_PROMPT = os.environ.get('STYLE_PROMPT')
 CONTEXT_LENGTH = int(os.environ.get('CONTEXT_LENGTH'))
 TEMPERATURE = float(os.environ.get('TEMPERATURE'))
-TOP_P = float(os.environ.get('TOP_P'))
-FREQUENCY_PENALTY = float(os.environ.get('FREQUENCY_PENALTY'))
-PRESENCE_PENALTY = float(os.environ.get('PRESENCE_PENALTY'))
-MAX_TOKENS = int(os.environ.get('MAX_TOKENS'))
+MAX_COMPLETION_TOKENS = int(os.environ.get('MAX_TOKENS'))
+BOT_NAME = os.environ.get('BOT_NAME', 'assistant')
+GEMINI_API_KEY = os.environ.get('GEMINI_API_KEY')
+GEMINI_IMAGE_MODEL = os.environ.get('GEMINI_IMAGE_MODEL', 'gemini-2.5-flash-image')
+IMAGE_MIME_TYPE = os.environ.get('IMAGE_MIME_TYPE', 'image/png')
+
+
+def _text_from_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                parts.append(item.get("text", ""))
+        return "\n".join(parts)
+    return str(content)
+
 
 class openaiClient:
-    def __init__(self, dynamoDB_client: dynamoDBClient()) -> None:
-        openai.api_key = OPENAI_KEY
+    def __init__(self, dynamoDB_client: dynamoDBClient) -> None:
+        self.client = OpenAI(api_key=OPENAI_KEY)
+        if GEMINI_API_KEY:
+            genai.configure(api_key=GEMINI_API_KEY)
+        else:
+            print("GEMINI_API_KEY is not set; image generation tool calls will fail.")
         self.dynamoDB_client = dynamoDB_client
-    
-    def complete_chat(self, user_message: str, chat_id: int, bot_id: int):
-        """ Generate the bot's answer to a user's message"""
-        previous_messages = self.dynamoDB_client.load_messages(f"{str(chat_id)}_{str(bot_id)}")[-CONTEXT_LENGTH:]
-        messages = [{"role": "system", "content": SYSTEM_PROMPT}] + \
-            previous_messages + \
-            [{"role": "user", "content": f"{user_message}\n{STYLE_PROMPT}"}]
-        print(messages)
-        
-        response = openai.ChatCompletion.create(
+
+    def _chat_key(self, chat_id: int, bot_id: int) -> str:
+        return f"{str(chat_id)}_{str(bot_id)}"
+
+    def _format_message_for_model(self, message: Dict[str, Any], include_style_prompt: bool = False) -> Dict[str, Any]:
+        prefix = f"[msg:{message.get('id')}] @{message.get('username', 'user')}"
+        if message.get("reply_to_id"):
+            prefix += f" (in reply to msg:{message['reply_to_id']})"
+        text_body = message.get("text", "")
+        if include_style_prompt and STYLE_PROMPT:
+            text_body = f"{text_body}\n{STYLE_PROMPT}"
+        content_parts: List[Dict[str, Any]] = [{"type": "text", "text": f"{prefix}:\n{text_body}"}]
+        for image in message.get("images", []):
+            content_parts.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:{IMAGE_MIME_TYPE};base64,{image}"}
+            })
+        return {"role": message.get("role", "user"), "content": content_parts}
+
+    def _trim_and_save_messages(self, chat_key: str, messages: List[Dict[str, Any]]):
+        trimmed = messages[-CONTEXT_LENGTH:]
+        self.dynamoDB_client.save_messages(chat_key, trimmed)
+
+    def _build_tools(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "generate_image",
+                    "description": "Create an illustrative image with Gemini based on the chat context.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "prompt": {
+                                "type": "string",
+                                "description": "Target visual description to render."
+                            },
+                            "size": {
+                                "type": "string",
+                                "description": "Preferred image size, such as 1024x1024.",
+                            }
+                        },
+                        "required": ["prompt"],
+                    },
+                },
+            }
+        ]
+
+    def _summarize_conversation(self, messages: List[Dict[str, Any]]) -> str:
+        lines = []
+        for message in messages:
+            prefix = f"[msg:{message.get('id')}] @{message.get('username', 'user')}"
+            if message.get("reply_to_id"):
+                prefix += f" replying to msg:{message['reply_to_id']}"
+            text_body = message.get("text", "")
+            lines.append(f"{prefix}: {text_body}")
+        return "\n".join(lines)
+
+    def _generate_image(self, prompt: str, size: Optional[str]) -> Optional[Dict[str, Any]]:
+        model = genai.GenerativeModel(GEMINI_IMAGE_MODEL)
+        generation_config: Dict[str, Any] = {"response_mime_type": IMAGE_MIME_TYPE}
+        if size:
+            generation_config["image_size"] = size
+        try:
+            response = model.generate_content(
+                [prompt],
+                generation_config=generation_config,
+            )
+        except Exception as exc:
+            print(f"Gemini generation failed: {exc}")
+            return None
+        if not response or not response.candidates:
+            return None
+        candidate = response.candidates[0]
+        if not candidate.content or not candidate.content.parts:
+            return None
+        for part in candidate.content.parts:
+            if hasattr(part, "inline_data") and part.inline_data and getattr(part.inline_data, "data", None):
+                return {
+                    "data": part.inline_data.data,
+                    "mime_type": part.inline_data.mime_type or IMAGE_MIME_TYPE,
+                    "prompt": prompt
+                }
+        return None
+
+    def _handle_tool_calls(self, tool_calls, conversation_messages: List[Dict[str, Any]], base_messages):
+        tool_responses = []
+        generated_images: List[Dict[str, Any]] = []
+        for tool_call in tool_calls:
+            if tool_call.function.name == "generate_image":
+                args = json.loads(tool_call.function.arguments)
+                prompt = args.get("prompt", "")
+                size = args.get("size")
+                prompt_with_history = f"{prompt}\n\nConversation summary:\n{self._summarize_conversation(conversation_messages)}"
+                image_result = self._generate_image(prompt_with_history, size)
+                if image_result:
+                    generated_images.append(image_result)
+                    tool_responses.append({
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "content": json.dumps({
+                            "status": "image_generated",
+                            "prompt": prompt_with_history,
+                            "mime_type": image_result.get("mime_type", IMAGE_MIME_TYPE)
+                        }),
+                    })
+                else:
+                    tool_responses.append({
+                        "role": "tool",
+                        "tool_call_id": tool_call.id,
+                        "content": json.dumps({
+                            "status": "failed",
+                            "reason": "Image generation returned no data"
+                        }),
+                    })
+        if not tool_responses:
+            return None, [], base_messages
+        follow_up_messages = base_messages + tool_responses
+        response = self.client.chat.completions.create(
             model=OPENAI_MODEL,
-            messages = messages,
+            messages=follow_up_messages,
             temperature=TEMPERATURE,
-            max_completion_tokens=MAX_TOKENS,
-            #max_tokens=MAX_TOKENS,
-            #top_p=TOP_P,
-            #frequency_penalty=FREQUENCY_PENALTY,
-            #presence_penalty=PRESENCE_PENALTY,
+            max_completion_tokens=MAX_COMPLETION_TOKENS,
+            tools=self._build_tools(),
         )
-        answer = response["choices"][0]["message"]["content"]
-        print(answer)
-        previous_messages = previous_messages + [{"role": "user", "content": user_message}, {"role": "assistant", "content": answer}]
-        previous_messages = previous_messages[-CONTEXT_LENGTH:] 
-        self.dynamoDB_client.save_messages(f"{str(chat_id)}_{str(bot_id)}", previous_messages)
-        return answer
+        return response.choices[0].message, generated_images, follow_up_messages
+
+    def remember_only(self, chat_id: int, bot_id: int, message: Dict[str, Any]):
+        chat_key = self._chat_key(chat_id, bot_id)
+        previous_messages = self.dynamoDB_client.load_messages(chat_key)
+        updated_messages = previous_messages + [message]
+        self._trim_and_save_messages(chat_key, updated_messages)
+
+    def complete_chat(self, user_message: Dict[str, Any], chat_id: int, bot_id: int):
+        """Generate the bot's answer to a user's message"""
+        chat_key = self._chat_key(chat_id, bot_id)
+        previous_messages = self.dynamoDB_client.load_messages(chat_key)
+        limited_previous = previous_messages[-CONTEXT_LENGTH:]
+        formatted_history = [self._format_message_for_model(m) for m in limited_previous]
+        model_messages = [{"role": "system", "content": [{"type": "text", "text": SYSTEM_PROMPT}]}] + formatted_history + [
+            self._format_message_for_model(user_message, include_style_prompt=True)
+        ]
+
+        response = self.client.chat.completions.create(
+            model=OPENAI_MODEL,
+            messages=model_messages,
+            temperature=TEMPERATURE,
+            max_completion_tokens=MAX_COMPLETION_TOKENS,
+            tools=self._build_tools(),
+        )
+
+        first_choice = response.choices[0].message
+        assistant_message = first_choice
+        tool_generated_images: List[Dict[str, Any]] = []
+        if first_choice.tool_calls:
+            assistant_message, tool_generated_images, _ = self._handle_tool_calls(
+                first_choice.tool_calls,
+                limited_previous + [user_message],
+                model_messages + [first_choice.model_dump()]
+            )
+
+        assistant_text = _text_from_content(assistant_message.content)
+        assistant_images = [
+            base64.b64encode(image_data["data"]).decode("utf-8")
+            if isinstance(image_data.get("data"), (bytes, bytearray))
+            else image_data.get("data")
+            for image_data in tool_generated_images
+        ]
+        assistant_images = [img for img in assistant_images if img]
+        assistant_metadata = [
+            {
+                "prompt": image_data.get("prompt"),
+                "mime_type": image_data.get("mime_type", IMAGE_MIME_TYPE),
+            }
+            for image_data in tool_generated_images
+        ]
+        assistant_record = {
+            "role": "assistant",
+            "username": BOT_NAME,
+            "text": assistant_text,
+            "id": f"{user_message.get('id', uuid.uuid4().hex)}-assistant",
+            "reply_to_id": user_message.get("id"),
+            "images": assistant_images,
+            "tool_images_meta": assistant_metadata,
+        }
+
+        updated_history = limited_previous + [user_message, assistant_record]
+        self._trim_and_save_messages(chat_key, updated_history)
+
+        return assistant_record

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-openai==0.27.2
+openai>=1.40.3
+google-generativeai>=0.8.3
+urllib3>=1.26.18

--- a/telegram_client.py
+++ b/telegram_client.py
@@ -1,8 +1,10 @@
+import base64
 import json
 import os
 import urllib3
 import random
 import re
+from typing import Any, Dict, List, Optional
 
 from openai_client import openaiClient
 from dinamodb_client import dynamoDBClient
@@ -16,6 +18,9 @@ RESET_COMMAND = os.environ.get('RESET_COMMAND')
 CONTEXT_LENGTH = int(os.environ.get('CONTEXT_LENGTH'))
 
 SEND_MESSAGE_URL = 'https://api.telegram.org/bot' + TELEGRAM_TOKEN + '/sendMessage'
+SEND_PHOTO_URL = 'https://api.telegram.org/bot' + TELEGRAM_TOKEN + '/sendPhoto'
+GET_FILE_URL = 'https://api.telegram.org/bot' + TELEGRAM_TOKEN + '/getFile'
+FILE_DOWNLOAD_URL = 'https://api.telegram.org/file/bot' + TELEGRAM_TOKEN + '/{}'
 http = urllib3.PoolManager()
 
 dynamoDB_client = dynamoDBClient()
@@ -37,18 +42,18 @@ def format_for_telegram(text: str) -> str:
         r'\|\|(?:.|\n)*?\|\|',
     ]
     master_pattern = re.compile('|'.join(patterns), re.DOTALL)
-    
+
     protected_blocks = []
-    
+
     def _protect_block(match):
         placeholder = f"UNBREAKABLEPLACEHOLDER{len(protected_blocks)}UNBREAKABLE"
         protected_blocks.append(match.group(0))
         return placeholder
-    
+
     text_with_placeholders = master_pattern.sub(_protect_block, text)
 
     # Шаг 3: Экранируем оставшиеся спецсимволы.
-    escape_chars = r'_*[]()~`>#+-=|{}.!' 
+    escape_chars = r'_*[]()~`>#+-=|{}.!'
     escape_pattern = f'([{re.escape(escape_chars)}])'
     escaped_text = re.sub(escape_pattern, r'\\\1', text_with_placeholders)
 
@@ -56,22 +61,20 @@ def format_for_telegram(text: str) -> str:
     for i, block in enumerate(protected_blocks):
         placeholder_to_replace = f"UNBREAKABLEPLACEHOLDER{i}UNBREAKABLE"
         escaped_text = escaped_text.replace(placeholder_to_replace, block)
-        
-    return escaped_text
 
-import re
+    return escaped_text
 
 def format_with_code_blocks(text: str) -> str:
     """
     A controlled formatter for Telegram MarkdownV2.
-    
+
     This function's priorities are:
     1. Preserve all code blocks (`...` and ```...```) perfectly.
     2. Escape all other special characters to prevent API errors.
     """
     # A list to store the code blocks we find.
     code_blocks = []
-    
+
     # A simple function to replace a found code block with a placeholder.
     def _protect_code_block(match):
         # Add the found code block (e.g., `my_variable`) to our list.
@@ -92,7 +95,7 @@ def format_with_code_blocks(text: str) -> str:
     final_text = remaining_text_escaped
     for i, block in enumerate(code_blocks):
         final_text = final_text.replace(f"CODEBLOCKPLACEHOLDER{i}", block)
-        
+
     return final_text
 
 def format_with_styles(text: str) -> str:
@@ -102,7 +105,7 @@ def format_with_styles(text: str) -> str:
     """
     # A list to store the protected formatting blocks.
     protected_blocks = []
-    
+
     # The function to replace a found block with a placeholder.
     def _protect_block(match):
         protected_blocks.append(match.group(0))
@@ -118,7 +121,7 @@ def format_with_styles(text: str) -> str:
         r'_(?:.|\n)*?_',      # Italic
     ]
     master_pattern = re.compile('|'.join(patterns), re.DOTALL)
-    
+
     # Run the replacement to protect all specified markdown.
     text_with_placeholders = master_pattern.sub(_protect_block, text)
 
@@ -130,14 +133,61 @@ def format_with_styles(text: str) -> str:
     final_text = remaining_text_escaped
     for i, block in enumerate(protected_blocks):
         final_text = final_text.replace(f"PROTECTEDBLOCK{i}", block)
-        
+
     return final_text
+
+
+def _username_from_message(message: Dict[str, Any]) -> str:
+    return message.get("from", {}).get("username") or message.get("from", {}).get("first_name") or "unknown_user"
+
+
+def _download_file(file_id: str) -> Optional[bytes]:
+    file_payload = {"file_id": file_id}
+    response = http.request('POST', GET_FILE_URL,
+                            headers={'Content-Type': 'application/json'},
+                            body=json.dumps(file_payload), timeout=10)
+    response_data = json.loads(response.data.decode())
+    if not response_data.get("ok"):
+        return None
+    file_path = response_data.get("result", {}).get("file_path")
+    if not file_path:
+        return None
+    file_url = FILE_DOWNLOAD_URL.format(file_path)
+    file_response = http.request('GET', file_url, timeout=10)
+    if file_response.status != 200:
+        return None
+    return file_response.data
+
+
+def _extract_images(message: Dict[str, Any]) -> List[str]:
+    images: List[str] = []
+    if "photo" in message:
+        photo_sizes = message["photo"]
+        if isinstance(photo_sizes, list) and photo_sizes:
+            selected_photo = photo_sizes[-1]
+            file_id = selected_photo.get("file_id")
+            if file_id:
+                raw = _download_file(file_id)
+                if raw:
+                    images.append(base64.b64encode(raw).decode("utf-8"))
+    return images
+
+
+def _structured_user_message(message: Dict[str, Any], user_message: str) -> Dict[str, Any]:
+    return {
+        "role": "user",
+        "username": _username_from_message(message),
+        "text": user_message,
+        "id": str(message.get("message_id")),
+        "reply_to_id": str(message.get("reply_to_message", {}).get("message_id")) if message.get("reply_to_message") else None,
+        "images": _extract_images(message),
+    }
 
 
 class telegramClient:
     def __init__(self) -> None:
         pass
-    
+
     def send_message(self, text: str, chat_id, original_message_id):
         """ Reply to a message of a user
 
@@ -152,25 +202,45 @@ class telegramClient:
             "text": format_with_code_blocks(text),
             "reply_to_message_id": original_message_id
         }
-        response = http.request('POST', SEND_MESSAGE_URL, 
+        response = http.request('POST', SEND_MESSAGE_URL,
                                 headers={'Content-Type': 'application/json'},
                                 body=json.dumps(payload), timeout=10)
         print(response.data)
-    
-    def should_reply(self, message:dict):
+
+    def send_photo(self, chat_id: int, image_bytes: bytes, caption: str, original_message_id: int, mime_type: str = "image/png"):
+        fields = {
+            "chat_id": str(chat_id),
+            "caption": format_with_code_blocks(caption),
+            "reply_to_message_id": str(original_message_id),
+            "parse_mode": "MarkdownV2",
+            "photo": (f"image.{mime_type.split('/')[-1]}", image_bytes, mime_type),
+        }
+        response = http.request(
+            'POST',
+            SEND_PHOTO_URL,
+            fields=fields,
+            encode_multipart=True,
+        )
+        print(response.data)
+
+    def should_reply(self, message: dict):
         """ The function that decides whether the bot should reply to a message or not """
+        entities = message.get("entities") or []
+        mentions_bot = any(
+            entity.get("type") == "mention" and ("@" + BOT_NAME) in message.get("text", "")
+            for entity in entities
+        )
         if (
             (message["from"]["id"] == message["chat"]["id"]) or
-            ("reply_to_message" in message and message["reply_to_message"]["from"]["id"] == BOT_ID) or
-            ("entities" in message and message["entities"][0]["type"] == "mention" and ("@" + BOT_NAME) in message["text"])
+            ("reply_to_message" in message and message["reply_to_message"].get("from", {}).get("id") == BOT_ID) or
+            mentions_bot
         ):
             return True
-        else:
-            bet = random.random()
-            if bet < FREQUENCY:
-                return True
+        bet = random.random()
+        if bet < FREQUENCY:
+            return True
         return False
-    
+
     def process_message(self, body):
         """ Process a message of a user and with some probability reply to it
 
@@ -180,13 +250,13 @@ class telegramClient:
         print(body)
         if (
             "message" in body and
-            (not body["message"]["from"]["is_bot"] or body["message"]["from"]["username"]=="GroupAnonymousBot") and
+            (not body["message"]["from"]["is_bot"] or body["message"]["from"].get("username") == "GroupAnonymousBot") and
             "forward_from_message_id" not in body["message"]
             ):
             message = body["message"]
-            
+
             chat_id = message["chat"]["id"]
-            message_id=message["message_id"]
+            message_id = message["message_id"]
             if chat_id not in ALLOWED_CHATS:
                 print(f"{chat_id} is not allower")
                 return
@@ -194,21 +264,31 @@ class telegramClient:
             if "entities" in message and message["entities"][0]["type"]  == "bot_command" and  ("/" + RESET_COMMAND) in message["text"]:
                 dynamoDB_client.reset_chat(f"{str(chat_id)}_{str(BOT_ID)}")
                 return
-            
+
             # Extract the message of a user
             if "text" in body["message"]:
                 user_message = message["text"]
             elif "sticker" in body["message"] and "emoji" in body["message"]["sticker"]:
                 user_message = message["sticker"]["emoji"]
-            elif "photo" in body["message"] and "caption" in body["message"]:
-                user_message = message["caption"]
+            elif "photo" in body["message"]:
+                user_message = message.get("caption", "Image shared without caption")
             else:
                 return
 
+            structured_message = _structured_user_message(message, user_message.replace("@" + BOT_NAME, ""))
+
             if self.should_reply(message):
-                user_message = user_message.replace("@" + BOT_NAME, "")
-                bot_message = openai_client.complete_chat(user_message, chat_id, BOT_ID)
-                self.send_message(bot_message, chat_id, message_id)
+                bot_message = openai_client.complete_chat(structured_message, chat_id, BOT_ID)
+                reply_text = f"[msg:{bot_message['id']}] (reply to msg:{bot_message.get('reply_to_id')})\n{bot_message['text']}"
+                if bot_message.get("text"):
+                    self.send_message(reply_text, chat_id, message_id)
+                if bot_message.get("tool_images_meta"):
+                    for image_meta, encoded in zip(bot_message.get("tool_images_meta", []), bot_message.get("images", [])):
+                        if not encoded:
+                            continue
+                        image_bytes = base64.b64decode(encoded)
+                        caption = f"[msg:{bot_message['id']}] Image created for msg:{structured_message['id']}\n{image_meta.get('prompt', '')}"
+                        self.send_photo(chat_id, image_bytes, caption, message_id, image_meta.get("mime_type", "image/png"))
             else:
                 previous_messages = dynamoDB_client.load_messages(f"{str(chat_id)}_{str(BOT_ID)}")[-CONTEXT_LENGTH:]
-                dynamoDB_client.save_messages(f"{str(chat_id)}_{str(BOT_ID)}", previous_messages[-(CONTEXT_LENGTH-1):] + [{"role": "user", "content": user_message}])
+                dynamoDB_client.save_messages(f"{str(chat_id)}_{str(BOT_ID)}", previous_messages[-(CONTEXT_LENGTH-1):] + [structured_message])


### PR DESCRIPTION
## Summary

Upgraded dependencies to modern OpenAI and Gemini libraries to support multimodal and image-generation workflows.

DynamoDB persistence now keeps message IDs, usernames, reply links, and optional images while remaining backward compatible with legacy records.

The OpenAI client now builds prompts with usernames/message IDs, includes attached photos, and services Gemini-powered tool calls before storing assistant replies.

Telegram handling fetches user photos for VLM prompts, prefixes messages with usernames/IDs, and returns generated images through sendPhoto alongside reply-aware text.

Added documentation for new Gemini configuration needs plus deployment reminders for Lambda and Telegram webhook updates.

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928bc6e09c0832f83698eede854f5c2)