### PR TITLE
Add current datetime to LLM prompt context

### DIFF
--- a/openai_client.py
+++ b/openai_client.py
@@ -3,6 +3,7 @@ import os
 import json
 import uuid
 import re
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from google import genai
@@ -326,11 +327,14 @@ class openaiClient:
         
         # Filter out orphaned tool messages that would cause OpenAI API errors
         limited_previous = self._filter_valid_tool_messages(limited_previous)
-        
+
         formatted_history = [self._format_message_for_model(m) for m in limited_previous]
         tool_instruction = "TOOL USAGE INSTRUCTIONS: If any member of the chat asks to create, draw or render an image or a picture in any language, always call the `generate_image` tool and do not describe the JSON yourself or answer with some text. Otherwise return concise, human-friendly answers without technical prefixes. "
+        current_time = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S %Z")
+        time_instruction = f"Current date and time (UTC): {current_time}. Use this to keep your answers time-aware."
         model_messages = [
             {"role": "system", "content": [{"type": "text", "text": SYSTEM_PROMPT}]},
+            {"role": "system", "content": [{"type": "text", "text": time_instruction}]},
             {"role": "system", "content": [{"type": "text", "text": tool_instruction}]},
         ] + formatted_history + [self._format_message_for_model(user_message, include_style_prompt=True)]
 


### PR DESCRIPTION
## Summary
- include current UTC date and time in system prompts so the model can give time-aware responses
- add datetime import to support generating the timestamp instruction

## Testing
- python -m pytest *(fails: missing boto3 dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929dd2f3a10832f9528435e7520729e)